### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 molecule[ansible,lint]
 molecule-vagrant
 python-vagrant
+wheel


### PR DESCRIPTION
Added 'wheel' package to allow macos to not have to use legacy 'setup.py install' on packages that have a wheel already created.